### PR TITLE
Add configurable HTTP User-Agent for SAML AWS requests and test support

### DIFF
--- a/src/main/java/org/mskcc/cbio/oncokb/config/application/SamlAwsProperties.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/config/application/SamlAwsProperties.java
@@ -7,6 +7,7 @@ public class SamlAwsProperties {
     private String principalArn; // The Amazon Resource Name (ARN) of the SAML provider in IAM that describes the IdP.
     private String roleArn; // The Amazon Resource Name (ARN) of the role that the caller is assuming.
     private String region = "us-east-1";
+    private String httpUserAgent;
 
 
     public String getServiceAccountUsername() {
@@ -47,6 +48,14 @@ public class SamlAwsProperties {
 
     public void setRegion(String region) {
         this.region = region;
+    }
+
+    public String getHttpUserAgent() {
+        return this.httpUserAgent;
+    }
+
+    public void setHttpUserAgent(String httpUserAgent) {
+        this.httpUserAgent = httpUserAgent;
     }
 
 }

--- a/src/main/java/org/mskcc/cbio/oncokb/service/SamlService.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/service/SamlService.java
@@ -2,6 +2,7 @@ package org.mskcc.cbio.oncokb.service;
 
 import java.util.function.Supplier;
 import javax.annotation.PostConstruct;
+import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -35,9 +36,15 @@ public class SamlService {
     private final Integer SESSION_DURATION_IN_SECONDS = 28800;  // 8 hours, the maximum allowable 
 
     private final ApplicationProperties applicationProperties;
+    private final RestTemplate restTemplate;
 
     public SamlService(ApplicationProperties applicationProperties) {
+        this(applicationProperties, new RestTemplate());
+    }
+
+    SamlService(ApplicationProperties applicationProperties, RestTemplate restTemplate) {
         this.applicationProperties = applicationProperties;
+        this.restTemplate = restTemplate;
     }
 
     @PostConstruct
@@ -71,11 +78,13 @@ public class SamlService {
     }
 
     private String getSamlResponse() throws RuntimeException {
-
-        RestTemplate restTemplate = new RestTemplate();
-
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        String httpUserAgent = applicationProperties.getSamlAws().getHttpUserAgent();
+        if (StringUtils.isNotBlank(httpUserAgent)) {
+            headers.set(HttpHeaders.USER_AGENT, httpUserAgent);
+        }
 
         MultiValueMap<String, String> map = new LinkedMultiValueMap<String, String>();
         map.add(MSK_USERNAME_FIELD, applicationProperties.getSamlAws().getServiceAccountUsername());

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -176,6 +176,7 @@ application:
     service-account-password:
     principal-arn: # "arn:aws:iam::[account number]:saml-provider/PingFed"
     role-arn: # "arn:aws:iam::[account number]:role/mskAutomationUser"
+    http-user-agent: # required for S3 allow-listing in AWS
   github-token:
   github-search-sleep-ms: 10000
   db-read-only: false # Certain endpoints will be disabled when readonly is set to true

--- a/src/test/java/org/mskcc/cbio/oncokb/service/SamlServiceTest.java
+++ b/src/test/java/org/mskcc/cbio/oncokb/service/SamlServiceTest.java
@@ -1,0 +1,97 @@
+package org.mskcc.cbio.oncokb.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mskcc.cbio.oncokb.config.application.ApplicationProperties;
+import org.mskcc.cbio.oncokb.config.application.SamlAwsProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+class SamlServiceTest {
+
+    private static final String IDP_URL = "https://ssofed.mskcc.org/idp/startSSO.ping?PartnerSpId=urn:amazon:webservices";
+
+    @Test
+    void getSamlResponseShouldSetConfiguredUserAgentHeader() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        SamlService samlService = new SamlService(buildApplicationProperties("test-allowed-agent/1.0"), restTemplate);
+
+        server
+            .expect(requestTo(IDP_URL))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(header(HttpHeaders.USER_AGENT, "test-allowed-agent/1.0"))
+            .andExpect(content().string("pf.username=service-user&pf.pass=service-pass"))
+            .andRespond(withSuccess("<html><input name=\"SAMLResponse\" value=\"encoded-saml\"/></html>", MediaType.TEXT_HTML));
+
+        String samlResponse = ReflectionTestUtils.invokeMethod(samlService, "getSamlResponse");
+
+        assertEquals("encoded-saml", samlResponse);
+        server.verify();
+    }
+
+    @Test
+    void getSamlResponseShouldNotSetUserAgentHeaderWhenBlank() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        SamlService samlService = new SamlService(buildApplicationProperties("   "), restTemplate);
+
+        server
+            .expect(requestTo(IDP_URL))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(request -> {
+                MockClientHttpRequest mockRequest = (MockClientHttpRequest) request;
+                List<String> userAgentHeaders = mockRequest.getHeaders().get(HttpHeaders.USER_AGENT);
+                if (userAgentHeaders != null && !userAgentHeaders.isEmpty()) {
+                    throw new AssertionError("Expected no User-Agent header, but found: " + userAgentHeaders);
+                }
+            })
+            .andRespond(withSuccess("<html><input name=\"SAMLResponse\" value=\"encoded-saml\"/></html>", MediaType.TEXT_HTML));
+
+        String samlResponse = ReflectionTestUtils.invokeMethod(samlService, "getSamlResponse");
+
+        assertEquals("encoded-saml", samlResponse);
+        server.verify();
+    }
+
+    @Test
+    void getSamlResponseShouldThrowWhenSamlResponseInputIsMissing() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        SamlService samlService = new SamlService(buildApplicationProperties("test-allowed-agent/1.0"), restTemplate);
+
+        server.expect(requestTo(IDP_URL)).andRespond(withSuccess("<html><body>No assertion</body></html>", MediaType.TEXT_HTML));
+
+        RuntimeException exception = assertThrows(RuntimeException.class, () ->
+            ReflectionTestUtils.invokeMethod(samlService, "getSamlResponse")
+        );
+
+        assertEquals("Could not find SAMLResponse value in SAML assertion response", exception.getMessage());
+        server.verify();
+    }
+
+    private ApplicationProperties buildApplicationProperties(String httpUserAgent) {
+        SamlAwsProperties samlAwsProperties = new SamlAwsProperties();
+        samlAwsProperties.setServiceAccountUsername("service-user");
+        samlAwsProperties.setServiceAccountPassword("service-pass");
+        samlAwsProperties.setHttpUserAgent(httpUserAgent);
+
+        ApplicationProperties applicationProperties = new ApplicationProperties();
+        applicationProperties.setSamlAws(samlAwsProperties);
+
+        return applicationProperties;
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow configuring the HTTP `User-Agent` sent to the SAML IdP because certain AWS workflows (like S3 allow-listing) require an explicit agent string.
- Improve testability of the SAML request logic by enabling injection of a `RestTemplate` into `SamlService`.

### Description
- Add `httpUserAgent` property with getter/setter to `SamlAwsProperties`.
- Set the `User-Agent` header in `SamlService#getSamlResponse` when `applicationProperties.getSamlAws().getHttpUserAgent()` is not blank, using `StringUtils.isNotBlank` to guard it.
- Make `SamlService` injectable-test-friendly by adding a package-private constructor that accepts a `RestTemplate` and keeping the default constructor that delegates to `new RestTemplate()`.
- Add `saml-aws.http-user-agent` entry to `application-dev.yml` and add `SamlServiceTest` unit tests covering header present, header omitted when blank, and missing `SAMLResponse` handling.

### Testing
- Added `SamlServiceTest` with three tests: `getSamlResponseShouldSetConfiguredUserAgentHeader`, `getSamlResponseShouldNotSetUserAgentHeaderWhenBlank`, and `getSamlResponseShouldThrowWhenSamlResponseInputIsMissing`, and ran them as unit tests; they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ce24dda88322bd196a0746d738ff)